### PR TITLE
`schedule list_daily` : アサイン情報が存在しないジョブ、存在しないメンバーに紐づいても出力できるようにする

### DIFF
--- a/annoworkcli/schedule/list_assigned_hours_daily_groupby_tag.py
+++ b/annoworkcli/schedule/list_assigned_hours_daily_groupby_tag.py
@@ -68,7 +68,7 @@ class ListAssignedHoursDailyGroupbyTag:
         # 全体の時間を日毎に集計する
 
         # key:job_id, value:job_nameのdict
-        job_dict: dict[str, str] = {}
+        job_dict: dict[str, Optional[str]] = {}
         for elm in assigned_hours_list:
             dict_hours[elm.date, elm.job_id, "total"] += elm.assigned_working_hours
             job_dict[elm.job_id] = elm.job_name


### PR DESCRIPTION
# 背景
Annowork画面で以下の操作を行うと、存在しないプロジェクトに紐づくアサイン情報が作成されてしまう。
1. スケジュール画面で、プロジェクトXに対してアサインする
2. プロジェクト画面で、プロジェクトXを削除する

このアサイン情報を`annoworkcli list_daily`コマンドで出力しようとすると、エラーが発生する。
※ `annoworkcli list`コマンドでは出力できる。
イレギュラーではあるが、このようなアサイン情報も出力したいときがあるので、エラーを発生せずに出力できるようにする。


