### PR TITLE
annofab配下のコマンドに、コマンドライン引数 `--annofab_mfa_code` を追加した。

### DIFF
--- a/annoworkcli/annofab/list_job_with_annofab_project.py
+++ b/annoworkcli/annofab/list_job_with_annofab_project.py
@@ -7,13 +7,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 import pandas
-from annofabapi import build as build_annofabapi
 from annofabapi.resource import Resource as AnnofabResource
 from annoworkapi.annofab import get_annofab_project_id_from_url
 from annoworkapi.job import get_parent_job_id_from_job_tree
 from annoworkapi.resource import Resource as AnnoworkResource
 
 import annoworkcli
+from annoworkcli.annofab.utils import build_annofabapi_resource_and_login
 from annoworkcli.common.annofab import get_annofab_project_id_from_job
 from annoworkcli.common.cli import OutputFormat, build_annoworkapi, get_list_from_args
 from annoworkcli.common.utils import print_csv, print_json
@@ -113,7 +113,7 @@ class ListJobWithAnnofabProject:
                 job["annofab"] = None
                 continue
 
-            af_project = af_project_dict[af_project_id]
+            af_project = af_project_dict.get(af_project_id)
             if af_project is None:
                 logger.warning(
                     f"annofab_project_id='{af_project_id}' のAnnofabプロジェクトを取得できませんでした。:: job_id={job['job_id']}"
@@ -139,7 +139,7 @@ def main(args):
     main_obj = ListJobWithAnnofabProject(
         annowork_service=annowork_service,
         workspace_id=args.workspace_id,
-        annofab_service=build_annofabapi(),
+        annofab_service=build_annofabapi_resource_and_login(mfa_code=args.annofab_mfa_code),
         parallelism=args.parallelism,
     )
     job_list = main_obj.get_job_list_added_annofab_project(
@@ -211,6 +211,7 @@ def parse_args(parser: argparse.ArgumentParser):
 
     parser.add_argument("--parallelism", type=int, required=False, help="並列度。指定しない場合は、逐次的に処理します。")
 
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
     parser.set_defaults(subcommand_func=main)
 
 

--- a/annoworkcli/annofab/list_working_hours.py
+++ b/annoworkcli/annofab/list_working_hours.py
@@ -10,7 +10,6 @@ from typing import Any, Collection, Optional
 
 import pandas
 import requests
-from annofabapi import build as build_annofabapi
 from annofabapi.resource import Resource as AnnofabResource
 from annoworkapi.job import get_parent_job_id_from_job_tree
 from annoworkapi.resource import Resource as AnnoworkResource
@@ -22,6 +21,7 @@ from annoworkcli.actual_working_time.list_actual_working_hours_daily import (
     filter_actual_daily_list,
 )
 from annoworkcli.actual_working_time.list_actual_working_time import ListActualWorkingTime
+from annoworkcli.annofab.utils import build_annofabapi_resource_and_login
 from annoworkcli.common.annofab import TIMEZONE_OFFSET_HOURS, get_annofab_project_id_from_job, isoduration_to_hour
 from annoworkcli.common.cli import OutputFormat, build_annoworkapi, get_list_from_args
 from annoworkcli.common.utils import print_csv, print_json
@@ -439,7 +439,7 @@ def main(args):
     main_obj = ListWorkingHoursWithAnnofab(
         annowork_service=build_annoworkapi(args),
         workspace_id=args.workspace_id,
-        annofab_service=build_annofabapi(),
+        annofab_service=build_annofabapi_resource_and_login(mfa_code=args.annofab_mfa_code),
         parallelism=args.parallelism,
     )
 
@@ -515,7 +515,7 @@ def parse_args(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument("--parallelism", type=int, required=False, help="並列度。指定しない場合は、逐次的に処理します。")
-
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
     parser.set_defaults(subcommand_func=main)
 
 

--- a/annoworkcli/annofab/put_account_external_linkage_info.py
+++ b/annoworkcli/annofab/put_account_external_linkage_info.py
@@ -4,11 +4,11 @@ import argparse
 import logging
 from typing import Any, Optional
 
-from annofabapi import build as build_annofabapi
 from annofabapi.resource import Resource as AnnofabResource
 from annoworkapi.resource import Resource as AnnoworkResource
 
 import annoworkcli
+from annoworkcli.annofab.utils import build_annofabapi_resource_and_login
 from annoworkcli.common.cli import build_annoworkapi, get_list_from_args
 
 logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ class PutAnnofabAccountId:
 
 def main(args):
     annowork_service = build_annoworkapi(args)
-    annofab_service = build_annofabapi()
+    annofab_service = build_annofabapi_resource_and_login(mfa_code=args.annofab_mfa_code)
     user_id_list = get_list_from_args(args.user_id)
     assert user_id_list is not None
     PutAnnofabAccountId(
@@ -112,7 +112,7 @@ def parse_args(parser: argparse.ArgumentParser):
         default=False,
         help="上書きする",
     )
-
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
     parser.set_defaults(subcommand_func=main)
 
 

--- a/annoworkcli/annofab/put_job_from_annofab_project.py
+++ b/annoworkcli/annofab/put_job_from_annofab_project.py
@@ -4,11 +4,11 @@ import argparse
 import logging
 from typing import Optional
 
-from annofabapi import build as build_annofabapi
 from annofabapi.resource import Resource as AnnofabResource
 from annoworkapi.resource import Resource as AnnoworkResource
 
 import annoworkcli
+from annoworkcli.annofab.utils import build_annofabapi_resource_and_login
 from annoworkcli.common.cli import build_annoworkapi
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,9 @@ class PutJobFromAnnofabProject:
 def main(args):
     annowork_service = build_annoworkapi(args)
     main_obj = PutJobFromAnnofabProject(
-        annowork_service=annowork_service, workspace_id=args.workspace_id, annofab_service=build_annofabapi()
+        annowork_service=annowork_service,
+        workspace_id=args.workspace_id,
+        annofab_service=build_annofabapi_resource_and_login(mfa_code=args.annofab_mfa_code),
     )
     main_obj.put_job_from_annofab_project(
         parent_job_id=args.parent_job_id, annofab_project_id=args.annofab_project_id, job_id=args.job_id
@@ -96,7 +98,7 @@ def parse_args(parser: argparse.ArgumentParser):
         required=False,
         help="追加するジョブのjob_idを指定してください。未指定の場合は ``--annofab_project_id`` の値と同じです。",
     )
-
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
     parser.set_defaults(subcommand_func=main)
 
 

--- a/annoworkcli/annofab/reshape_working_hours.py
+++ b/annoworkcli/annofab/reshape_working_hours.py
@@ -10,13 +10,13 @@ from typing import Any, Collection, Optional
 
 import numpy
 import pandas
-from annofabapi import build as build_annofabapi
 from annofabapi.resource import Resource as AnnofabResource
 from annoworkapi.job import get_parent_job_id_from_job_tree
 from annoworkapi.resource import Resource as AnnoworkResource
 
 import annoworkcli
 from annoworkcli.annofab.list_working_hours import ListWorkingHoursWithAnnofab
+from annoworkcli.annofab.utils import build_annofabapi_resource_and_login
 from annoworkcli.common.annofab import get_annofab_project_id_from_job
 from annoworkcli.common.cli import build_annoworkapi, get_list_from_args
 from annoworkcli.common.utils import print_csv
@@ -1067,7 +1067,7 @@ def main(args):
     main_obj = ReshapeWorkingHours(
         annowork_service=build_annoworkapi(args),
         workspace_id=args.workspace_id,
-        annofab_service=build_annofabapi(),
+        annofab_service=build_annofabapi_resource_and_login(mfa_code=args.annofab_mfa_code),
         parallelism=args.parallelism,
     )
 
@@ -1232,7 +1232,7 @@ def parse_args(parser: argparse.ArgumentParser):
     parser.add_argument("--parallelism", type=int, required=False, help="並列度。指定しない場合は、逐次的に処理します。")
 
     parser.add_argument("-o", "--output", type=Path, help="出力先")
-
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
     parser.set_defaults(subcommand_func=main)
 
 

--- a/annoworkcli/annofab/utils.py
+++ b/annoworkcli/annofab/utils.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import annofabapi
+from annofabapi import build as build_annofabapi
+from annofabapi.exceptions import MfaEnabledUserExecutionError as AnnofabApiMfaEnabledUserExecutionError
+
+
+def build_annofabapi_resource_and_login(*, mfa_code: Optional[str] = None) -> annofabapi.Resource:
+    """
+    annofabapi.Resourceインスタンスを生成したあと、ログインする。
+
+    Args:
+        args: コマンドライン引数の情報
+
+    Returns:
+        annofabapi.Resourceインスタンス
+
+    """
+
+    service = build_annofabapi()
+
+    try:
+        if mfa_code is not None:
+            service.api.login(mfa_code=mfa_code)
+        else:
+            service.api.login()
+        return service
+
+    except AnnofabApiMfaEnabledUserExecutionError:
+        # 標準入力からMFAコードを入力させる
+        inputted_mfa_code = ""
+        while inputted_mfa_code == "":
+            inputted_mfa_code = input("Enter MFA Code for Annofab: ")
+
+        service.api.login(mfa_code=inputted_mfa_code)
+        return service

--- a/annoworkcli/annofab/visualize_statistics.py
+++ b/annoworkcli/annofab/visualize_statistics.py
@@ -213,6 +213,9 @@ def visualize_statistics(temp_dir: Path, args):
     if args.output_dir is not None:
         command.extend(["--output_dir", str(args.output_dir)])
 
+    if args.annofab_mfa_code is not None:
+        command.extend(["--mfa_code", str(args.annofab_mfa_code)])
+
     if args.annofabcli_options is not None:
         command.extend(args.annofabcli_options)
 
@@ -248,6 +251,8 @@ def parse_args(parser: argparse.ArgumentParser):
     parser.add_argument("--end_date", type=str, required=False, help="集計終了日(YYYY-mm-dd)")
 
     parser.add_argument("--temp_dir", type=Path, required=False, help="テンポラリディレクトリ")
+
+    parser.add_argument("--annofab_mfa_code", type=str, help="Annofabにログインする際のMFAコード")
 
     # 残りの引数は `annofabcli statistics visualize`コマンドにそのまま渡す
     parser.add_argument(

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,14 +29,14 @@ files = [
 
 [[package]]
 name = "annofabapi"
-version = "0.68.0"
+version = "0.72.1"
 description = "Python Clinet Library of Annofab WebAPI (https://annofab.com/docs/api/)"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "annofabapi-0.68.0-py3-none-any.whl", hash = "sha256:288da6f33e20a4dc5574a9c6b026bb0060236bf716d590889d69296e7cada87f"},
-    {file = "annofabapi-0.68.0.tar.gz", hash = "sha256:4b5116e8ffdc5a41f825611d22f5ef255cdc116621ee61eda73ba8cdf5378e55"},
+    {file = "annofabapi-0.72.1-py3-none-any.whl", hash = "sha256:578f7b0aa81eb37058c001431236d462c427df2156e274f7199cd9b22f97bc03"},
+    {file = "annofabapi-0.72.1.tar.gz", hash = "sha256:67bbd39b340a27f974372f2ea092a6a223e69cb7986c40fc640e200cebd2a41d"},
 ]
 
 [package.dependencies]
@@ -46,21 +46,24 @@ more-itertools = "*"
 python-dateutil = "*"
 requests = "*"
 
+[package.extras]
+segmentation = ["numpy", "numpy (<1.25)", "numpy (>=1.26)", "pillow"]
+
 [[package]]
 name = "annofabcli"
-version = "1.76.1"
+version = "1.78.1"
 description = "Utility Command Line Interface for AnnoFab"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "annofabcli-1.76.1-py3-none-any.whl", hash = "sha256:5237bb334eef51c46f99aa8a2669a5b81bc253d17e2c043161894990b3ec6313"},
-    {file = "annofabcli-1.76.1.tar.gz", hash = "sha256:d27e8d92c53466d4efbc92d8cde0dab424ffd7a2902eddb56b7ff8d281c27016"},
+    {file = "annofabcli-1.78.1-py3-none-any.whl", hash = "sha256:981bc0310e12dfda6567f98f3bd524b5d85b59d49980e8f93f48528b8e4bcbd5"},
+    {file = "annofabcli-1.78.1.tar.gz", hash = "sha256:80c8b3e17c76501934a79f58896649935cd604ae590150ad4294bacfd361674d"},
 ]
 
 [package.dependencies]
-annofabapi = ">=0.67.1"
-bokeh = ">=3.0,<4.0"
+annofabapi = ">=0.72.0"
+bokeh = ">=3.0.0,<3.1.0"
 dictdiffer = "*"
 isodate = "*"
 jmespath = "*"
@@ -71,6 +74,7 @@ pyquery = "*"
 python-datauri = "*"
 pyyaml = "*"
 requests = "*"
+typing-extensions = ">=4.5,<5.0"
 
 [[package]]
 name = "annoworkapi"
@@ -264,20 +268,20 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bokeh"
-version = "3.1.0"
+version = "3.0.3"
 description = "Interactive plots and applications in the browser from Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "bokeh-3.1.0-py3-none-any.whl", hash = "sha256:9d38ed3b130e1e043447694934c02deb1ae4adfeda1136b8b8eaed9cb26de11c"},
-    {file = "bokeh-3.1.0.tar.gz", hash = "sha256:9047dfe50a671b5e19ca588fd90a8e6bff197114a5dbd6a59cc2678942c27887"},
+    {file = "bokeh-3.0.3-py3-none-any.whl", hash = "sha256:d30e4f6220efc824c5da0dcb58138abed0e6a2d524c942409c8ca1098031e374"},
+    {file = "bokeh-3.0.3.tar.gz", hash = "sha256:1c28471ef5e6110ba5bed513137fd26054ebc4454bc768650eaeefc53b898a8a"},
 ]
 
 [package.dependencies]
 contourpy = ">=1"
 Jinja2 = ">=2.9"
-numpy = ">=1.16"
+numpy = ">=1.11.3"
 packaging = ">=16.8"
 pandas = ">=1.2"
 pillow = ">=7.1.0"


### PR DESCRIPTION
AnnofabではMFAを有効にできる。
`annofab`配下のコマンドはannofab web apiにアクセスするため、MFAコードを指定する必要がある。

コマンドライン引数`--annofab_mfa_code`からMFAコードを指定できるようにした。
この引数を指定しない場合は、標準入力からMFAコードを入力できる。
