### PR TITLE
`annofab reshape_working_hours` : `--actual_file`を指定したときはAnnofab APIにアクセスしないようにする

### DIFF
--- a/annoworkcli/__main__.py
+++ b/annoworkcli/__main__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import argparse
 import copy
 import logging


### PR DESCRIPTION
# 現状
常にAnnofabの`login` APIを実行する。
そのため、MFAを有効化している場合は必ずMFAコードの入力が求められる。
しかし`--actual_file`を指定する場合はAnnofab APIにアクセスする必要はない。

# 対応方法
`--actual_file`を指定した場合あｈ、Annofabの`login` APIを実行しないようにした。
