### PR TITLE
`from __future__ import annotations`を除去する 

### DIFF
--- a/annoworkcli/__main__.py
+++ b/annoworkcli/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import copy
 import logging

--- a/annoworkcli/account/list_external_linkage_info.py
+++ b/annoworkcli/account/list_external_linkage_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/account/put_external_linkage_info.py
+++ b/annoworkcli/account/put_external_linkage_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/annoworkcli/actual_working_time/delete_actual_working_time.py
+++ b/annoworkcli/actual_working_time/delete_actual_working_time.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import sys

--- a/annoworkcli/actual_working_time/list_actual_working_hours_daily.py
+++ b/annoworkcli/actual_working_time/list_actual_working_hours_daily.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import datetime
 import json

--- a/annoworkcli/actual_working_time/list_actual_working_hours_daily_groupby_tag.py
+++ b/annoworkcli/actual_working_time/list_actual_working_hours_daily_groupby_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from collections import defaultdict

--- a/annoworkcli/actual_working_time/list_actual_working_time.py
+++ b/annoworkcli/actual_working_time/list_actual_working_time.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import datetime
 import logging

--- a/annoworkcli/annofab/list_job_with_annofab_project.py
+++ b/annoworkcli/annofab/list_job_with_annofab_project.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import multiprocessing

--- a/annoworkcli/annofab/list_working_hours.py
+++ b/annoworkcli/annofab/list_working_hours.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import functools
 import itertools

--- a/annoworkcli/annofab/put_account_external_linkage_info.py
+++ b/annoworkcli/annofab/put_account_external_linkage_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Optional

--- a/annoworkcli/annofab/put_job_from_annofab_project.py
+++ b/annoworkcli/annofab/put_job_from_annofab_project.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Optional

--- a/annoworkcli/annofab/reshape_working_hours.py
+++ b/annoworkcli/annofab/reshape_working_hours.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-lines
-from __future__ import annotations
+
 
 import argparse
 import json

--- a/annoworkcli/annofab/visualize_statistics.py
+++ b/annoworkcli/annofab/visualize_statistics.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import datetime
 import logging

--- a/annoworkcli/common/annofab.py
+++ b/annoworkcli/common/annofab.py
@@ -1,7 +1,7 @@
 """
 annofabに関するutil関係の関数
 """
-from __future__ import annotations
+
 
 from typing import Any, Optional
 

--- a/annoworkcli/common/job.py
+++ b/annoworkcli/common/job.py
@@ -1,4 +1,3 @@
 """
 jobに関するutil関係の関数
 """
-from __future__ import annotations

--- a/annoworkcli/common/workspace_tag.py
+++ b/annoworkcli/common/workspace_tag.py
@@ -1,7 +1,7 @@
 """
 workspace_tag に関するutil関係の関数
 """
-from __future__ import annotations
+
 
 from typing import Optional
 

--- a/annoworkcli/expected_working_time/delete_expected_working_time.py
+++ b/annoworkcli/expected_working_time/delete_expected_working_time.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Optional

--- a/annoworkcli/expected_working_time/list_expected_working_time.py
+++ b/annoworkcli/expected_working_time/list_expected_working_time.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import sys

--- a/annoworkcli/expected_working_time/list_expected_working_time_groupby_tag.py
+++ b/annoworkcli/expected_working_time/list_expected_working_time_groupby_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import sys

--- a/annoworkcli/expected_working_time/list_expected_working_time_weekly.py
+++ b/annoworkcli/expected_working_time/list_expected_working_time_weekly.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import sys

--- a/annoworkcli/job/change_job_properties.py
+++ b/annoworkcli/job/change_job_properties.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Optional

--- a/annoworkcli/job/delete_job.py
+++ b/annoworkcli/job/delete_job.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Optional

--- a/annoworkcli/job/list_job.py
+++ b/annoworkcli/job/list_job.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/my/get_my_account.py
+++ b/annoworkcli/my/get_my_account.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/schedule/list_assigned_hours_daily.py
+++ b/annoworkcli/schedule/list_assigned_hours_daily.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from collections import defaultdict

--- a/annoworkcli/schedule/list_assigned_hours_daily_groupby_tag.py
+++ b/annoworkcli/schedule/list_assigned_hours_daily_groupby_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from collections import defaultdict

--- a/annoworkcli/schedule/list_schedule.py
+++ b/annoworkcli/schedule/list_schedule.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/workspace/list_workspace.py
+++ b/annoworkcli/workspace/list_workspace.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/workspace/put_workspace.py
+++ b/annoworkcli/workspace/put_workspace.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Optional

--- a/annoworkcli/workspace_member/append_tag_to_workspace_member.py
+++ b/annoworkcli/workspace_member/append_tag_to_workspace_member.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Collection, Optional

--- a/annoworkcli/workspace_member/change_workspace_member_properties.py
+++ b/annoworkcli/workspace_member/change_workspace_member_properties.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Collection, Optional

--- a/annoworkcli/workspace_member/delete_workspace_member.py
+++ b/annoworkcli/workspace_member/delete_workspace_member.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Optional

--- a/annoworkcli/workspace_member/list_workspace_member.py
+++ b/annoworkcli/workspace_member/list_workspace_member.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from pathlib import Path

--- a/annoworkcli/workspace_member/put_workspace_member.py
+++ b/annoworkcli/workspace_member/put_workspace_member.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import uuid

--- a/annoworkcli/workspace_member/remove_tag_to_workspace_member.py
+++ b/annoworkcli/workspace_member/remove_tag_to_workspace_member.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 from typing import Any, Collection, Optional

--- a/annoworkcli/workspace_tag/put_workspace_tag.py
+++ b/annoworkcli/workspace_tag/put_workspace_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import logging
 import uuid


### PR DESCRIPTION
Python3.8のサポートを終了したので、`from __future__ import annotations`を除去しました。