### PR TITLE
`annofab visualize_statistics` : `--labor_csv`に渡すCSVは`date`,`account_id`,`project_id`のペアがユニークになるようにする

### DIFF
--- a/annoworkcli/annofab/visualize_statistics.py
+++ b/annoworkcli/annofab/visualize_statistics.py
@@ -156,7 +156,7 @@ def mask_credential_in_command(command: list[str]) -> list[str]:
         command: 実行するコマンドのリスト（変更されません）
     """
     tmp_command = copy.deepcopy(command)
-    for masked_option in ["--annofab_user_id", "--annofab_password"]:
+    for masked_option in ["--annofab_user_id", "--annofab_password", "--annofab_pat"]:
         try:
             index = tmp_command.index(masked_option)
             tmp_command[index + 1] = "***"


### PR DESCRIPTION
# 背景
AnnofabプロジェクトXに紐づくジョブAとジョブBがある状態で、ユーザMが2024-10-03にジョブAに2時間とジョブBに3時間の実績作業時間を入力すると、`annofabcli statistics visualize`コマンドの`--labor_csv`に渡すCSVは以下のようになる。

```
date,account_id,project_id
2024-10-03,account-M,project-X,2
2024-10-03,account-M,project-X,3
```

annofabcli側では、date,account_id,project_idのペアがユニークであること前提になっているため、正しくない結果になる。

# 対応したこと
`--labor_csv`に渡すCSVは、date,account_id,project_idのペアがユニークになるようにした。

