### PR TITLE
出力結果であるCSVファイルで`parent_job`の順番を変える

### DIFF
--- a/annoworkcli/actual_working_time/list_actual_working_hours_daily.py
+++ b/annoworkcli/actual_working_time/list_actual_working_hours_daily.py
@@ -226,10 +226,10 @@ class ListActualWorkingHoursDaily:
 def get_required_columns() -> list[str]:
     required_columns = [
         "date",
-        "job_id",
-        "job_name",
         "parent_job_id",
         "parent_job_name",
+        "job_id",
+        "job_name",
         "workspace_member_id",
         "user_id",
         "username",

--- a/annoworkcli/actual_working_time/list_actual_working_hours_daily_groupby_tag.py
+++ b/annoworkcli/actual_working_time/list_actual_working_hours_daily_groupby_tag.py
@@ -170,10 +170,10 @@ class ListActualWorkingTimeGroupbyTag:
             df.fillna(0, inplace=True)
             required_columns = [
                 "date",
-                "job_id",
-                "job_name",
                 "parent_job_id",
                 "parent_job_name",
+                "job_id",
+                "job_name",
                 "actual_working_hours.total",
             ]
 

--- a/annoworkcli/actual_working_time/list_actual_working_time.py
+++ b/annoworkcli/actual_working_time/list_actual_working_time.py
@@ -232,10 +232,10 @@ class ListActualWorkingTime:
             required_columns = [
                 "workspace_id",
                 "actual_working_time_id",
-                "job_id",
-                "job_name",
                 "parent_job_id",
                 "parent_job_name",
+                "job_id",
+                "job_name",
                 "workspace_member_id",
                 "user_id",
                 "username",

--- a/annoworkcli/annofab/list_working_hours.py
+++ b/annoworkcli/annofab/list_working_hours.py
@@ -280,6 +280,8 @@ class ListWorkingHoursWithAnnofab:
     @staticmethod
     def _get_required_columns() -> list[str]:
         job_columns = [
+            "parent_job_id",
+            "parent_job_name",
             "job_id",
             "job_name",
         ]
@@ -290,11 +292,7 @@ class ListWorkingHoursWithAnnofab:
         ]
         annofab_columns = ["annofab_project_id", "annofab_project_title", "annofab_account_id", "annofab_working_hours"]
 
-        parent_job_columns = [
-            "parent_job_id",
-            "parent_job_name",
-        ]
-        required_columns = ["date"] + job_columns + parent_job_columns + user_columns + ["actual_working_hours"] + annofab_columns  # noqa: RUF005
+        required_columns = ["date", *job_columns, *user_columns, "actual_working_hours", *annofab_columns]
 
         required_columns.append("notes")
         return required_columns


### PR DESCRIPTION
# 変更前
CSVファイルでは、`job_name`、`parent_job_name`列の順に出力されていました。
`job_name`より`parent_job_name`列が先に表示されている方が、CSVファイルとして見やすかったので、列の順番を変更しました。

# 変更後
`parent_job_name`、`job_name`列の順に出力するようにしました。

# 変更したコマンド
* `actual_working_time list`
* `actual_working_time list_daily`
* `actual_working_time list_daily_groupby_tag`
* `annofab list_working_hours`
