### PR TITLE
"schedule_actual list_daily "：正しく予定作業時間が取得できない問題を修正しました。

### DIFF
--- a/annoworkcli/schedule_actual/common.py
+++ b/annoworkcli/schedule_actual/common.py
@@ -139,16 +139,15 @@ def get_daily_schedule_actual_df(
         actual_daily_df = pandas.DataFrame([e.to_dict() for e in actual_daily_list])
         actual_hours_by_date = _sum_working_hours_by_date(actual_daily_df, "actual_working_hours")
 
-    child_job_ids = list_actual_working_time_obj.get_child_job_id_list([parent_job_id])
     assigned_hours_by_date: dict[str, float] = {}
-    if len(child_job_ids) > 0 and (assigned_start_date is None or assigned_end_date is None or assigned_start_date <= assigned_end_date):
+    if assigned_start_date is None or assigned_end_date is None or assigned_start_date <= assigned_end_date:
         assigned_daily_list = ListAssignedHoursDaily(
             annowork_service=annowork_service,
             workspace_id=workspace_id,
         ).get_assigned_hours_daily_list(
             start_date=assigned_start_date,
             end_date=assigned_end_date,
-            job_ids=child_job_ids,
+            job_ids=[parent_job_id],
             user_ids=None,
         )
         assigned_daily_df = pandas.DataFrame([e.to_dict() for e in assigned_daily_list])

--- a/tests/schedule_actual/test_common.py
+++ b/tests/schedule_actual/test_common.py
@@ -1,4 +1,10 @@
-from annoworkcli.schedule_actual.common import build_daily_schedule_actual_df, build_weekly_schedule_actual_df
+from typing import TYPE_CHECKING, cast
+
+from annoworkcli.schedule.list_assigned_hours_daily import AssignedHoursDaily
+from annoworkcli.schedule_actual.common import build_daily_schedule_actual_df, build_weekly_schedule_actual_df, get_daily_schedule_actual_df
+
+if TYPE_CHECKING:
+    from annoworkapi.resource import Resource as AnnoworkResource
 
 
 def test_build_daily_schedule_actual_df():
@@ -81,4 +87,67 @@ def test_build_weekly_schedule_actual_df():
             "actual_working_hours": 0.0,
             "cumulative_working_hours": 10.0,
         },
+    ]
+
+
+def test_get_daily_schedule_actual_dfは親ジョブIDで作業計画を取得する(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class ListActualWorkingTimeStub:
+        def __init__(self, annowork_service, workspace_id, *, timezone_offset_hours):  # noqa: ANN001
+            pass
+
+        def get_actual_working_times(self, **_kwargs):  # noqa: ANN003, ANN201
+            return []
+
+    class ListAssignedHoursDailyStub:
+        def __init__(self, annowork_service, workspace_id):  # noqa: ANN001
+            pass
+
+        def get_assigned_hours_daily_list(self, *, start_date, end_date, job_ids, user_ids):  # noqa: ANN001, ANN201
+            captured["start_date"] = start_date
+            captured["end_date"] = end_date
+            captured["job_ids"] = job_ids
+            captured["user_ids"] = user_ids
+            return [
+                AssignedHoursDaily(
+                    date="2022-03-06",
+                    job_id="parent_job",
+                    job_name="親ジョブ",
+                    workspace_member_id="member",
+                    user_id="user",
+                    username="username",
+                    assigned_working_hours=5.0,
+                )
+            ]
+
+    def get_today_str_stub(*, timezone_offset_hours: float | None) -> str:  # noqa: ARG001
+        return "2022-03-06"
+
+    monkeypatch.setattr("annoworkcli.schedule_actual.common.get_today_str", get_today_str_stub)
+    monkeypatch.setattr("annoworkcli.schedule_actual.common.ListActualWorkingTime", ListActualWorkingTimeStub)
+    monkeypatch.setattr("annoworkcli.schedule_actual.common.ListAssignedHoursDaily", ListAssignedHoursDailyStub)
+
+    actual = get_daily_schedule_actual_df(
+        annowork_service=cast("AnnoworkResource", object()),
+        workspace_id="workspace",
+        parent_job_id="parent_job",
+        start_date="2022-03-06",
+        end_date="2022-03-06",
+        timezone_offset_hours=None,
+    )
+
+    assert captured == {
+        "start_date": "2022-03-06",
+        "end_date": "2022-03-06",
+        "job_ids": ["parent_job"],
+        "user_ids": None,
+    }
+    assert actual.to_dict("records") == [
+        {
+            "date": "2022-03-06",
+            "assigned_working_hours": 5.0,
+            "actual_working_hours": 0.0,
+            "cumulative_working_hours": 5.0,
+        }
     ]


### PR DESCRIPTION
## Summary
- Use parent_job_id directly as the schedule job_id when collecting future assigned hours for schedule_actual
- Add a regression test for the parent-job schedule lookup

## Tests
- make format
- make lint
- uv run pytest tests/schedule_actual/test_common.py tests/schedule_actual/test_schedule_actual_command.py